### PR TITLE
docs: add Community Help section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## 📣 Community Help
+
+If you have questions or need assistance with Infura services, please visit the [Infura Support Center](https://support.infura.io/).
+
+Please avoid opening GitHub Issues for support-related topics — they're intended for bugs and feature requests.
+
+
 # Infura
 
 **[Website](https://infura.io)**


### PR DESCRIPTION
This PR adds a "Community Help" section to the README, guiding users toward the Infura Support Center instead of using GitHub Issues for support-related questions. It improves onboarding clarity and aligns with best practices.
